### PR TITLE
Jg/queryrunner

### DIFF
--- a/plugin/trino-loki/src/main/java/io/trino/loki/LokiClient.java
+++ b/plugin/trino-loki/src/main/java/io/trino/loki/LokiClient.java
@@ -15,6 +15,7 @@ package io.trino.loki;
 
 import io.airlift.http.client.HttpUriBuilder;
 import io.trino.spi.TrinoException;
+import jakarta.inject.Inject;
 import okhttp3.*;
 
 import java.io.IOException;
@@ -32,6 +33,7 @@ public class LokiClient {
     private final OkHttpClient httpClient;
     private final URI lokiEndpoint;
 
+    @Inject
     public LokiClient(LokiConnectorConfig config) {
         this.lokiEndpoint = config.getLokiURI();
 

--- a/plugin/trino-loki/src/main/java/io/trino/loki/LokiClient.java
+++ b/plugin/trino-loki/src/main/java/io/trino/loki/LokiClient.java
@@ -13,6 +13,7 @@
  */
 package io.trino.loki;
 
+import com.google.common.collect.ImmutableSet;
 import io.airlift.http.client.HttpUriBuilder;
 import io.trino.spi.TrinoException;
 import jakarta.inject.Inject;
@@ -21,7 +22,9 @@ import okhttp3.*;
 import java.io.IOException;
 import java.net.URI;
 import java.time.Duration;
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import static com.google.common.net.HttpHeaders.AUTHORIZATION;
 import static io.trino.loki.LokiErrorCode.LOKI_UNKNOWN_ERROR;
@@ -83,6 +86,14 @@ public class LokiClient {
         catch (IOException e) {
             throw new TrinoException(LOKI_UNKNOWN_ERROR, "Error reading metrics", e);
         }
+    }
+
+    // TODO: do we need this?
+    public Set<String> getTableNames(String schema)
+    {
+        requireNonNull(schema, "schema is null");
+        String[] tables = {"this_client_does_not", "have_tables_as", "you_need_to_specify_a_table_function"};
+        return ImmutableSet.copyOf(tables);
     }
 
     public Response requestUri(URI uri) throws IOException

--- a/plugin/trino-loki/src/main/java/io/trino/loki/LokiClient.java
+++ b/plugin/trino-loki/src/main/java/io/trino/loki/LokiClient.java
@@ -14,15 +14,14 @@
 package io.trino.loki;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.inject.Inject;
 import io.airlift.http.client.HttpUriBuilder;
 import io.trino.spi.TrinoException;
-import jakarta.inject.Inject;
 import okhttp3.*;
 
 import java.io.IOException;
 import java.net.URI;
 import java.time.Duration;
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 

--- a/plugin/trino-loki/src/main/java/io/trino/loki/LokiConnector.java
+++ b/plugin/trino-loki/src/main/java/io/trino/loki/LokiConnector.java
@@ -13,11 +13,15 @@
  */
 package io.trino.loki;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.inject.Inject;
 import io.airlift.bootstrap.LifeCycleManager;
 import io.airlift.log.Logger;
 import io.trino.spi.connector.*;
+import io.trino.spi.function.table.ConnectorTableFunction;
 import io.trino.spi.transaction.IsolationLevel;
+
+import java.util.Set;
 
 import static java.util.Objects.requireNonNull;
 
@@ -28,18 +32,21 @@ public class LokiConnector implements Connector {
     private final LokiMetadata metadata;
     private final LokiSplitManager splitManager;
     private final LokiRecordSetProvider recordSetProvider;
+    private final Set<ConnectorTableFunction> connectorTableFunctions;
 
     @Inject
     public LokiConnector(
             LifeCycleManager lifeCycleManager,
             LokiMetadata metadata,
             LokiSplitManager splitManager,
-            LokiRecordSetProvider recordSetProvider)
+            LokiRecordSetProvider recordSetProvider,
+            Set<ConnectorTableFunction> connectorTableFunctions)
     {
         this.lifeCycleManager = requireNonNull(lifeCycleManager, "lifeCycleManager is null");
         this.metadata = requireNonNull(metadata, "metadata is null");
         this.splitManager = requireNonNull(splitManager, "splitManager is null");
         this.recordSetProvider = requireNonNull(recordSetProvider, "recordSetProvider is null");
+        this.connectorTableFunctions = ImmutableSet.copyOf(requireNonNull(connectorTableFunctions, "connectorTableFunctions is null"));
     }
 
     public enum LokiTransactionHandle
@@ -58,6 +65,12 @@ public class LokiConnector implements Connector {
     public ConnectorMetadata getMetadata(ConnectorSession session, ConnectorTransactionHandle transactionHandle)
     {
         return metadata;
+    }
+
+    @Override
+    public Set<ConnectorTableFunction> getTableFunctions()
+    {
+        return connectorTableFunctions;
     }
 
     @Override

--- a/plugin/trino-loki/src/main/java/io/trino/loki/LokiConnector.java
+++ b/plugin/trino-loki/src/main/java/io/trino/loki/LokiConnector.java
@@ -16,25 +16,70 @@ package io.trino.loki;
 import com.google.inject.Inject;
 import io.airlift.bootstrap.LifeCycleManager;
 import io.airlift.log.Logger;
-import io.trino.spi.connector.Connector;
+import io.trino.spi.connector.*;
+import io.trino.spi.transaction.IsolationLevel;
 
 import static java.util.Objects.requireNonNull;
 
 public class LokiConnector implements Connector {
     private static final Logger log = Logger.get(LokiConnector.class);
 
+    private final LifeCycleManager lifeCycleManager;
     private final LokiMetadata metadata;
     private final LokiSplitManager splitManager;
     private final LokiRecordSetProvider recordSetProvider;
 
     @Inject
     public LokiConnector(
+            LifeCycleManager lifeCycleManager,
             LokiMetadata metadata,
             LokiSplitManager splitManager,
             LokiRecordSetProvider recordSetProvider)
     {
+        this.lifeCycleManager = requireNonNull(lifeCycleManager, "lifeCycleManager is null");
         this.metadata = requireNonNull(metadata, "metadata is null");
         this.splitManager = requireNonNull(splitManager, "splitManager is null");
         this.recordSetProvider = requireNonNull(recordSetProvider, "recordSetProvider is null");
+    }
+
+    public enum LokiTransactionHandle
+            implements ConnectorTransactionHandle
+    {
+        INSTANCE
+    }
+
+    @Override
+    public ConnectorTransactionHandle beginTransaction(IsolationLevel isolationLevel, boolean readOnly, boolean autoCommit)
+    {
+        return LokiTransactionHandle.INSTANCE;
+    }
+
+    @Override
+    public ConnectorMetadata getMetadata(ConnectorSession session, ConnectorTransactionHandle transactionHandle)
+    {
+        return metadata;
+    }
+
+    @Override
+    public ConnectorSplitManager getSplitManager()
+    {
+        return splitManager;
+    }
+
+    @Override
+    public ConnectorRecordSetProvider getRecordSetProvider()
+    {
+        return recordSetProvider;
+    }
+
+    @Override
+    public final void shutdown()
+    {
+        try {
+            lifeCycleManager.stop();
+        }
+        catch (Exception e) {
+            log.error(e, "Error shutting down connector");
+        }
     }
 }

--- a/plugin/trino-loki/src/main/java/io/trino/loki/LokiConnectorConfig.java
+++ b/plugin/trino-loki/src/main/java/io/trino/loki/LokiConnectorConfig.java
@@ -38,7 +38,7 @@ public class LokiConnectorConfig {
 
     @Config("loki.uri")
     @ConfigDescription("Loki query endpoint") // TODO: decide if with or without /loki/api/v1/query
-    public LokiConnectorConfig setPrometheusURI(URI lokiURI)
+    public LokiConnectorConfig setLokiURI(URI lokiURI)
     {
         this.lokiURI = lokiURI;
         return this;

--- a/plugin/trino-loki/src/main/java/io/trino/loki/LokiMetadata.java
+++ b/plugin/trino-loki/src/main/java/io/trino/loki/LokiMetadata.java
@@ -13,7 +13,87 @@
  */
 package io.trino.loki;
 
-import io.trino.spi.connector.ConnectorMetadata;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.inject.Inject;
+import io.trino.spi.connector.*;
+
+import java.util.*;
+import java.util.function.UnaryOperator;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.spi.connector.RelationColumnsMetadata.forTable;
+import static java.util.Objects.requireNonNull;
 
 public class LokiMetadata implements ConnectorMetadata {
+    private final LokiClient lokiClient;
+
+    @Inject
+    public LokiMetadata(LokiClient lokiClient)
+    {
+        this.lokiClient = requireNonNull(lokiClient, "lokiClient is null");
+    }
+
+    @Override
+    public List<String> listSchemaNames(ConnectorSession session)
+    {
+        return listSchemaNames();
+    }
+
+    private static List<String> listSchemaNames()
+    {
+        return ImmutableList.copyOf(ImmutableSet.of("default"));
+    }
+
+
+    @Override
+    public List<SchemaTableName> listTables(ConnectorSession session, Optional<String> optionalSchemaName)
+    {
+        Set<String> schemaNames = optionalSchemaName.map(ImmutableSet::of)
+                .orElseGet(() -> ImmutableSet.copyOf(ImmutableSet.of("default")));
+
+        return schemaNames.stream()
+                .flatMap(schemaName ->
+                        lokiClient.getTableNames(schemaName).stream().map(tableName -> new SchemaTableName(schemaName, tableName)))
+                .collect(toImmutableList());
+    }
+
+    private List<SchemaTableName> listTables(ConnectorSession session, SchemaTablePrefix prefix)
+    {
+        if (prefix.getTable().isEmpty()) {
+            return listTables(session, prefix.getSchema());
+        }
+        return ImmutableList.of(prefix.toSchemaTableName());
+    }
+
+    @Override
+    public Iterator<RelationColumnsMetadata> streamRelationColumns(ConnectorSession session, Optional<String> schemaName, UnaryOperator<Set<SchemaTableName>> relationFilter)
+    {
+        Map<SchemaTableName, RelationColumnsMetadata> relationColumns = new HashMap<>();
+
+        SchemaTablePrefix prefix = schemaName.map(SchemaTablePrefix::new)
+                .orElseGet(SchemaTablePrefix::new);
+        for (SchemaTableName tableName : listTables(session, prefix)) {
+            ConnectorTableMetadata tableMetadata = getTableMetadata(tableName);
+            // table can disappear during listing operation
+            if (tableMetadata != null) {
+                relationColumns.put(tableName, forTable(tableName, tableMetadata.getColumns()));
+            }
+        }
+
+        return relationFilter.apply(relationColumns.keySet()).stream()
+                .map(relationColumns::get)
+                .iterator();
+    }
+
+    // TODO this always returns null
+    private ConnectorTableMetadata getTableMetadata(SchemaTableName tableName)
+    {
+        if (!listSchemaNames().contains(tableName.getSchemaName())) {
+            return null;
+        }
+
+        return null;
+
+    }
 }

--- a/plugin/trino-loki/src/main/java/io/trino/loki/LokiModule.java
+++ b/plugin/trino-loki/src/main/java/io/trino/loki/LokiModule.java
@@ -16,7 +16,9 @@ package io.trino.loki;
 import com.google.inject.Binder;
 import com.google.inject.Module;
 import com.google.inject.Scopes;
+import io.trino.spi.function.table.ConnectorTableFunction;
 
+import static com.google.inject.multibindings.Multibinder.newSetBinder;
 import static io.airlift.configuration.ConfigBinder.configBinder;
 
 public class LokiModule implements Module {
@@ -27,6 +29,7 @@ public class LokiModule implements Module {
         binder.bind(LokiClient.class).in(Scopes.SINGLETON);
         binder.bind(LokiSplitManager.class).in(Scopes.SINGLETON);
         binder.bind(LokiRecordSetProvider.class).in(Scopes.SINGLETON);
+        newSetBinder(binder, ConnectorTableFunction.class).addBinding().toProvider(LokiTableFunctionProvider.class).in(Scopes.SINGLETON);
         configBinder(binder).bindConfig(LokiConnectorConfig.class);
     }
 }

--- a/plugin/trino-loki/src/main/java/io/trino/loki/LokiTableFunction.java
+++ b/plugin/trino-loki/src/main/java/io/trino/loki/LokiTableFunction.java
@@ -1,0 +1,90 @@
+package io.trino.loki;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Strings;
+import io.trino.spi.TrinoException;
+import io.trino.spi.connector.ConnectorAccessControl;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorTransactionHandle;
+import io.trino.spi.function.table.*;
+import io.trino.spi.type.VarcharType;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static io.trino.spi.function.table.ReturnTypeSpecification.GenericTable.GENERIC_TABLE;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toList;
+
+public class LokiTableFunction
+        extends AbstractConnectorTableFunction
+{
+    public LokiTableFunction()
+    {
+        super(
+                "default",
+                "loki",
+                List.of(
+                        ScalarArgumentSpecification.builder()
+                                .name("RANGE")
+                                .type(INTEGER)
+                                .build(),
+                        ScalarArgumentSpecification.builder()
+                                .name("SELECTOR")
+                                .type(VarcharType.VARCHAR)
+                                .build()),
+                GENERIC_TABLE);
+    }
+
+    @Override
+    public TableFunctionAnalysis analyze(ConnectorSession session, ConnectorTransactionHandle transaction, Map<String, Argument> arguments, ConnectorAccessControl accessControl) {
+        long range = (long) ((ScalarArgument) arguments.get("RANGE")).getValue();
+        io.airlift.slice.Slice selector = (io.airlift.slice.Slice) ((ScalarArgument) arguments.get("SELECTOR")).getValue();
+        String strSelector = new String(selector.byteArray());
+
+
+        // custom validation of arguments
+        if (range > 0) {
+            throw new TrinoException(INVALID_FUNCTION_ARGUMENT, "column_count must be in range [1, 3]");
+        }
+
+        if (!Strings.isNullOrEmpty(strSelector)) {
+            throw new TrinoException(INVALID_FUNCTION_ARGUMENT, strSelector);
+        }
+
+        // determine the returned row type
+        List<Descriptor.Field> fields = List.of("col_a", "col_b", "col_c").subList(0, 3).stream()
+                .map(name -> new Descriptor.Field(name, Optional.of(BIGINT)))
+                .collect(toList());
+
+        Descriptor returnedType = new Descriptor(fields);
+
+        return TableFunctionAnalysis.builder()
+                .returnedType(returnedType)
+                .handle(new QueryHandle(new LokiTableHandle()))
+                .build();
+    }
+
+    public static class QueryHandle
+            implements ConnectorTableFunctionHandle
+    {
+        private final LokiTableHandle tableHandle;
+
+        @JsonCreator
+        public QueryHandle(@JsonProperty("tableHandle") LokiTableHandle tableHandle)
+        {
+            this.tableHandle = requireNonNull(tableHandle, "tableHandle is null");
+        }
+
+        @JsonProperty
+        public LokiTableHandle getTableHandle()
+        {
+            return tableHandle;
+        }
+    }
+}

--- a/plugin/trino-loki/src/main/java/io/trino/loki/LokiTableFunctionProvider.java
+++ b/plugin/trino-loki/src/main/java/io/trino/loki/LokiTableFunctionProvider.java
@@ -1,0 +1,26 @@
+package io.trino.loki;
+
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import io.trino.plugin.base.classloader.ClassLoaderSafeConnectorTableFunction;
+import io.trino.spi.function.table.ConnectorTableFunction;
+
+import static java.util.Objects.requireNonNull;
+
+public class LokiTableFunctionProvider
+        implements Provider<ConnectorTableFunction> {
+    //public static final String SCHEMA_NAME = "system";
+    //public static final String NAME = "query";
+
+    //private final LokiMetadata lokiMetadata;
+
+    @Inject
+    public LokiTableFunctionProvider(LokiMetadata lokiMetadata) {
+        //this.lokiMetadata = requireNonNull(lokiMetadata, "cassandraMetadata is null");
+    }
+
+    @Override
+    public ConnectorTableFunction get() {
+        return new ClassLoaderSafeConnectorTableFunction(new LokiTableFunction(), getClass().getClassLoader());
+    }
+}

--- a/plugin/trino-loki/src/main/java/io/trino/loki/LokiTableHandle.java
+++ b/plugin/trino-loki/src/main/java/io/trino/loki/LokiTableHandle.java
@@ -1,0 +1,4 @@
+package io.trino.loki;
+
+public class LokiTableHandle {
+}

--- a/plugin/trino-loki/src/test/java/io/trino/loki/LokiQueryRunner.java
+++ b/plugin/trino-loki/src/test/java/io/trino/loki/LokiQueryRunner.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.loki;
+
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import io.airlift.log.Logger;
+import io.airlift.units.Duration;
+import io.trino.plugin.base.util.Closables;
+import io.trino.testing.DistributedQueryRunner;
+import io.trino.testing.QueryRunner;
+
+import java.util.HashMap;
+import java.util.Map;
+
+
+import static io.trino.testing.TestingSession.testSessionBuilder;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+public final class LokiQueryRunner
+{
+    private LokiQueryRunner() {}
+
+    public static Builder builder(LokiServer lokiServer)
+    {
+        return new Builder()
+                .addConnectorProperty("loki.uri", lokiServer.getUri().toString());
+    }
+
+    public static class Builder
+            extends DistributedQueryRunner.Builder<Builder>
+    {
+        private final Map<String, String> connectorProperties = new HashMap<>();
+
+        protected Builder()
+        {
+            super(testSessionBuilder()
+                    .setCatalog("loki")
+                    .setSchema("default")
+                    .build());
+        }
+
+        @CanIgnoreReturnValue
+        public Builder addConnectorProperty(String key, String value)
+        {
+            this.connectorProperties.put(key, value);
+            return this;
+        }
+
+        @Override
+        public DistributedQueryRunner build()
+                throws Exception
+        {
+            DistributedQueryRunner queryRunner = super.build();
+            try {
+                queryRunner.installPlugin(new LokiPlugin());
+                queryRunner.createCatalog("loki", "loki", connectorProperties);
+            }
+            catch (Throwable e) {
+                Closables.closeAllSuppress(e, queryRunner);
+                throw e;
+            }
+            return queryRunner;
+        }
+    }
+
+    public static LokiClient createPrometheusClient(LokiServer server)
+    {
+        LokiConnectorConfig config = new LokiConnectorConfig();
+        config.setLokiURI(server.getUri());
+        config.setReadTimeout(new Duration(10, SECONDS));
+        return new LokiClient(config);
+    }
+
+    public static void main(String[] args)
+            throws Exception
+    {
+        QueryRunner queryRunner = builder(new LokiServer())
+                .addCoordinatorProperty("http-server.http.port", "8080")
+                .build();
+        Logger log = Logger.get(LokiQueryRunner.class);
+        log.info("======== SERVER STARTED ========");
+        log.info("\n====\n%s\n====", queryRunner.getCoordinator().getBaseUrl());
+    }
+}

--- a/plugin/trino-loki/src/test/java/io/trino/loki/LokiServer.java
+++ b/plugin/trino-loki/src/test/java/io/trino/loki/LokiServer.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.loki;
+
+import io.trino.testing.ResourcePresence;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+
+import java.io.Closeable;
+import java.net.URI;
+import java.time.Duration;
+
+import static org.testcontainers.utility.MountableFile.forClasspathResource;
+
+public class LokiServer
+        implements Closeable
+{
+    private static final int LOKI_PORT = 3100;
+    private static final String DEFAULT_VERSION = "3.1.0";
+
+    public static final String USER = "admin";
+    public static final String PASSWORD = "password";
+    public static final String LOKI_QUERY_API = "/loki/api/v1/query";
+
+    private final GenericContainer<?> dockerContainer;
+
+    public LokiServer()
+    {
+        this(DEFAULT_VERSION, false);
+    }
+
+    public LokiServer(String version, boolean enableBasicAuth)
+    {
+        this.dockerContainer = new GenericContainer<>("grafana/loki:" + version)
+                .withExposedPorts(LOKI_PORT);
+                //.waitingFor(Wait.forHttp(LOKI_QUERY_API).forResponsePredicate(response -> response.contains("\"status\"")))
+                //.withStartupTimeout(Duration.ofSeconds(360));
+        // Basic authentication was introduced in v2.24.0
+        if (enableBasicAuth) {
+            this.dockerContainer
+                    .withCommand("--config.file=/etc/prometheus/prometheus.yml", "--web.config.file=/etc/prometheus/web.yml")
+                    .withCopyFileToContainer(forClasspathResource("web.yml"), "/etc/prometheus/web.yml")
+                    .waitingFor(Wait.forHttp(LOKI_QUERY_API).forResponsePredicate(response -> response.contains("\"values\"")).withBasicCredentials(USER, PASSWORD))
+                    .withStartupTimeout(Duration.ofSeconds(360));
+        }
+        this.dockerContainer.start();
+    }
+
+    public URI getUri()
+    {
+        return URI.create("http://" + dockerContainer.getHost() + ":" + dockerContainer.getMappedPort(LOKI_PORT) + "/");
+    }
+
+    @Override
+    public void close()
+    {
+        dockerContainer.close();
+    }
+
+    @ResourcePresence
+    public boolean isRunning()
+    {
+        return dockerContainer.getContainerId() != null;
+    }
+}


### PR DESCRIPTION
This PR creates a test query runner and also fixes some small bugs on the plugin that was surfaced by this runner already.

Usage: when running the queryrunner locally, on can just
```
./client/trino-cli/target/trino-cli-453-executable.jar http://127.0.0.1:8080/loki/default
```
and try executing queries.