### PR TITLE
Add labels as maps

### DIFF
--- a/plugin/trino-loki/src/main/java/io/trino/loki/LokiMetadata.java
+++ b/plugin/trino-loki/src/main/java/io/trino/loki/LokiMetadata.java
@@ -106,8 +106,9 @@ public class LokiMetadata implements ConnectorMetadata {
 
         LokiTableHandle tableHandle = queryHandle.getTableHandle();
         List<ColumnHandle> columnHandles = ImmutableList.of(
-                new LokiColumnHandle("timestamp", TIMESTAMP_COLUMN_TYPE, 0),
-                new LokiColumnHandle("value", VarcharType.VARCHAR, 1)
+                new LokiColumnHandle("labels", VarcharType.VARCHAR, 0),
+                new LokiColumnHandle("timestamp", TIMESTAMP_COLUMN_TYPE, 1),
+                new LokiColumnHandle("value", VarcharType.VARCHAR, 2)
         );
         return Optional.of(new TableFunctionApplicationResult<>(tableHandle, columnHandles));
     }

--- a/plugin/trino-loki/src/main/java/io/trino/loki/LokiMetadata.java
+++ b/plugin/trino-loki/src/main/java/io/trino/loki/LokiMetadata.java
@@ -36,6 +36,9 @@ public class LokiMetadata implements ConnectorMetadata {
 
     // TODO: this might not be the right spot
     static final Type TIMESTAMP_COLUMN_TYPE = createTimestampWithTimeZoneType(3);
+    public Type getVarcharMapType() {
+        return this.lokiClient.getVarcharMapType();
+    }
 
     private static final Logger log = Logger.get(LokiMetadata.class);
 
@@ -106,7 +109,7 @@ public class LokiMetadata implements ConnectorMetadata {
 
         LokiTableHandle tableHandle = queryHandle.getTableHandle();
         List<ColumnHandle> columnHandles = ImmutableList.of(
-                new LokiColumnHandle("labels", VarcharType.VARCHAR, 0),
+                new LokiColumnHandle("labels", getVarcharMapType(), 0),
                 new LokiColumnHandle("timestamp", TIMESTAMP_COLUMN_TYPE, 1),
                 new LokiColumnHandle("value", VarcharType.VARCHAR, 2)
         );
@@ -129,7 +132,7 @@ public class LokiMetadata implements ConnectorMetadata {
         // TODO: base value column type on query
 
         var columns = ImmutableList.of(
-                        //new ColumnMetadata("labels", varcharMapType),
+                        new ColumnMetadata("labels", getVarcharMapType()),
                         new ColumnMetadata("timestamp", TIMESTAMP_COLUMN_TYPE),
                         new ColumnMetadata("value", VarcharType.VARCHAR)
         );

--- a/plugin/trino-loki/src/main/java/io/trino/loki/LokiRecordCursor.java
+++ b/plugin/trino-loki/src/main/java/io/trino/loki/LokiRecordCursor.java
@@ -47,13 +47,13 @@ public class LokiRecordCursor implements RecordCursor {
     private final List<LokiColumnHandle> columnHandles;
     private final int[] fieldToColumnIndex;
 
-    private final Iterator<XXEntry> entryItr;
+    private final Iterator<LabelledEntry> entryItr;
 
-    static class XXEntry {
+    static class LabelledEntry {
         public QueryResult.LogEntry entry;
         public Map<String, String> labels;
 
-        public XXEntry(QueryResult.LogEntry entry, Map<String,String> labels) {
+        public LabelledEntry(QueryResult.LogEntry entry, Map<String,String> labels) {
             super();
             this.entry = entry;
             this.labels = labels;
@@ -61,7 +61,7 @@ public class LokiRecordCursor implements RecordCursor {
 
     }
 
-    private XXEntry entry;
+    private LabelledEntry entry;
 
     public LokiRecordCursor(List<LokiColumnHandle> columnHandles, QueryResult result) {
         this.columnHandles = columnHandles;
@@ -75,7 +75,7 @@ public class LokiRecordCursor implements RecordCursor {
         this.entryItr = result.getData().getStreams()
                 .stream()
                 .flatMap(stream -> stream.getValues().stream()
-                .map(value -> new XXEntry(value, stream.getLabels()))).iterator();
+                .map(value -> new LabelledEntry(value, stream.getLabels()))).iterator();
     }
 
     @Override

--- a/plugin/trino-loki/src/main/java/io/trino/loki/LokiRecordCursor.java
+++ b/plugin/trino-loki/src/main/java/io/trino/loki/LokiRecordCursor.java
@@ -13,18 +13,17 @@
  */
 package io.trino.loki;
 
+import com.google.common.collect.ImmutableList;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
 import io.trino.spi.TrinoException;
-import io.trino.spi.block.ArrayBlockBuilder;
-import io.trino.spi.block.BlockBuilder;
-import io.trino.spi.block.MapBlockBuilder;
-import io.trino.spi.block.SqlMap;
+import io.trino.spi.block.*;
 import io.trino.spi.connector.RecordCursor;
 import io.trino.spi.type.*;
 
 import java.time.Instant;
 import java.time.ZoneId;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -110,12 +109,105 @@ public class LokiRecordCursor implements RecordCursor {
 
         int columnIndex = fieldToColumnIndex[field];
         return switch (columnIndex) {
-            case 0 -> entry.labels.toString().substring(0,60);
+            case 0 -> getSqlMapFromMap(columnHandles.get(columnIndex).columnType(), entry.labels);
             case 1 -> entry.entry.getTs();
             case 2 -> entry.entry.getLine();
             default -> null;
         };
     }
+
+    // Copy from prometheus to handle map<string,string>
+    static SqlMap getSqlMapFromMap(Type type, Map<?, ?> map)
+    {
+        // on functions like COUNT() the Type won't be a MapType
+        if (!(type instanceof MapType mapType)) {
+            return null;
+        }
+        Type keyType = mapType.getKeyType();
+        Type valueType = mapType.getValueType();
+
+        return buildMapValue(mapType, map.size(), (keyBuilder, valueBuilder) -> {
+            map.forEach((key, value) -> {
+                writeObject(keyBuilder, keyType, key);
+                writeObject(valueBuilder, valueType, value);
+            });
+        });
+    }
+
+    static Map<Object, Object> getMapFromSqlMap(Type type, SqlMap sqlMap)
+    {
+        MapType mapType = (MapType) type;
+        Type keyType = mapType.getKeyType();
+        Type valueType = mapType.getValueType();
+
+        int rawOffset = sqlMap.getRawOffset();
+        Block rawKeyBlock = sqlMap.getRawKeyBlock();
+        Block rawValueBlock = sqlMap.getRawValueBlock();
+
+        Map<Object, Object> map = new HashMap<>(sqlMap.getSize());
+        for (int i = 0; i < sqlMap.getSize(); i++) {
+            map.put(readObject(keyType, rawKeyBlock, rawOffset + i), readObject(valueType, rawValueBlock, rawOffset + i));
+        }
+        return map;
+    }
+
+    private static void writeObject(BlockBuilder builder, Type type, Object obj)
+    {
+        if (type instanceof ArrayType arrayType) {
+            Type elementType = arrayType.getElementType();
+            ((ArrayBlockBuilder) builder).buildEntry(elementBuilder -> {
+                for (Object item : (List<?>) obj) {
+                    writeObject(elementBuilder, elementType, item);
+                }
+            });
+        }
+        else if (type instanceof MapType mapType) {
+            ((MapBlockBuilder) builder).buildEntry((keyBuilder, valueBuilder) -> {
+                for (Map.Entry<?, ?> entry : ((Map<?, ?>) obj).entrySet()) {
+                    writeObject(keyBuilder, mapType.getKeyType(), entry.getKey());
+                    writeObject(valueBuilder, mapType.getValueType(), entry.getValue());
+                }
+            });
+        }
+        else {
+            if (BOOLEAN.equals(type)
+                    || TINYINT.equals(type)
+                    || SMALLINT.equals(type)
+                    || INTEGER.equals(type)
+                    || BIGINT.equals(type)
+                    || DOUBLE.equals(type)
+                    || type instanceof VarcharType) {
+                TypeUtils.writeNativeValue(type, builder, obj);
+            }
+        }
+    }
+
+    private static Object readObject(Type type, Block block, int position)
+    {
+        if (type instanceof ArrayType arrayType) {
+            Type elementType = arrayType.getElementType();
+            return getArrayFromBlock(elementType, arrayType.getObject(block, position));
+        }
+        if (type instanceof MapType mapType) {
+            return getMapFromSqlMap(type, mapType.getObject(block, position));
+        }
+        if (type.getJavaType() == Slice.class) {
+            Slice slice = (Slice) requireNonNull(TypeUtils.readNativeValue(type, block, position));
+            return (type instanceof VarcharType) ? slice.toStringUtf8() : slice.getBytes();
+        }
+
+        return TypeUtils.readNativeValue(type, block, position);
+    }
+
+    private static List<Object> getArrayFromBlock(Type elementType, Block block)
+    {
+        ImmutableList.Builder<Object> arrayBuilder = ImmutableList.builder();
+        for (int i = 0; i < block.getPositionCount(); ++i) {
+            arrayBuilder.add(readObject(elementType, block, i));
+        }
+        return arrayBuilder.build();
+    }
+    // End of copy from prometheus
 
     @Override
     public boolean getBoolean(int field) {

--- a/plugin/trino-loki/src/main/java/io/trino/loki/LokiRecordCursor.java
+++ b/plugin/trino-loki/src/main/java/io/trino/loki/LokiRecordCursor.java
@@ -116,7 +116,7 @@ public class LokiRecordCursor implements RecordCursor {
         };
     }
 
-    // Copy from prometheus to handle map<string,string>
+    // Copy from Loki to handle map<string,string>
     static SqlMap getSqlMapFromMap(Type type, Map<?, ?> map)
     {
         // on functions like COUNT() the Type won't be a MapType

--- a/plugin/trino-loki/src/main/java/io/trino/loki/LokiTableFunction.java
+++ b/plugin/trino-loki/src/main/java/io/trino/loki/LokiTableFunction.java
@@ -41,7 +41,9 @@ import static java.util.stream.Collectors.toList;
 public class LokiTableFunction
         extends AbstractConnectorTableFunction
 {
-    public LokiTableFunction()
+    private Type varcharMapType;
+
+    public LokiTableFunction(Type varcharMapType)
     {
         super(
                 "default",
@@ -62,6 +64,8 @@ public class LokiTableFunction
                                 .type(VarcharType.VARCHAR)
                                 .build()),
                 GENERIC_TABLE);
+
+        this.varcharMapType = varcharMapType;
     }
 
     @Override
@@ -78,8 +82,7 @@ public class LokiTableFunction
 
         // determine the returned row type
         List<Descriptor.Field> fields = ImmutableList.of(
-                // TODO have map instead of string?
-                new Descriptor.Field("labels", Optional.of(VarcharType.VARCHAR)),
+                new Descriptor.Field("labels", Optional.of(varcharMapType)),
                 new Descriptor.Field("timestamp", Optional.of(LokiMetadata.TIMESTAMP_COLUMN_TYPE)),
                 new Descriptor.Field("value", Optional.of(VarcharType.VARCHAR))
         );

--- a/plugin/trino-loki/src/main/java/io/trino/loki/LokiTableFunction.java
+++ b/plugin/trino-loki/src/main/java/io/trino/loki/LokiTableFunction.java
@@ -22,9 +22,7 @@ import io.trino.spi.connector.ConnectorAccessControl;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorTransactionHandle;
 import io.trino.spi.function.table.*;
-import io.trino.spi.type.LongTimestampWithTimeZone;
-import io.trino.spi.type.TimeZoneKey;
-import io.trino.spi.type.VarcharType;
+import io.trino.spi.type.*;
 
 import java.time.Instant;
 import java.util.ArrayList;
@@ -80,6 +78,8 @@ public class LokiTableFunction
 
         // determine the returned row type
         List<Descriptor.Field> fields = ImmutableList.of(
+                // TODO have map instead of string?
+                new Descriptor.Field("labels", Optional.of(VarcharType.VARCHAR)),
                 new Descriptor.Field("timestamp", Optional.of(LokiMetadata.TIMESTAMP_COLUMN_TYPE)),
                 new Descriptor.Field("value", Optional.of(VarcharType.VARCHAR))
         );

--- a/plugin/trino-loki/src/main/java/io/trino/loki/LokiTableFunctionProvider.java
+++ b/plugin/trino-loki/src/main/java/io/trino/loki/LokiTableFunctionProvider.java
@@ -25,15 +25,15 @@ public class LokiTableFunctionProvider
     //public static final String SCHEMA_NAME = "system";
     //public static final String NAME = "query";
 
-    //private final LokiMetadata lokiMetadata;
+    private final LokiMetadata lokiMetadata;
 
     @Inject
     public LokiTableFunctionProvider(LokiMetadata lokiMetadata) {
-        //this.lokiMetadata = requireNonNull(lokiMetadata, "cassandraMetadata is null");
+        this.lokiMetadata = requireNonNull(lokiMetadata, "lokimetadata is null");
     }
 
     @Override
     public ConnectorTableFunction get() {
-        return new ClassLoaderSafeConnectorTableFunction(new LokiTableFunction(), getClass().getClassLoader());
+        return new ClassLoaderSafeConnectorTableFunction(new LokiTableFunction(this.lokiMetadata.getVarcharMapType()), getClass().getClassLoader());
     }
 }

--- a/plugin/trino-loki/src/test/java/io/trino/loki/LokiQueryRunner.java
+++ b/plugin/trino-loki/src/test/java/io/trino/loki/LokiQueryRunner.java
@@ -27,6 +27,7 @@ import java.util.Map;
 
 
 import static io.trino.testing.TestingSession.testSessionBuilder;
+import static io.trino.type.InternalTypeManager.TESTING_TYPE_MANAGER;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 public final class LokiQueryRunner
@@ -81,7 +82,7 @@ public final class LokiQueryRunner
         LokiConnectorConfig config = new LokiConnectorConfig();
         config.setLokiURI(server.getUri());
         config.setReadTimeout(new Duration(10, SECONDS));
-        return new LokiClient(config);
+        return new LokiClient(config, TESTING_TYPE_MANAGER);
     }
 
     public static void main(String[] args)


### PR DESCRIPTION
This builds on top of #6 . Maps the stream labels to individual rows, ~but sadly I did not have the patience to figure out how map types are working with trino~.

I have hacked trough wiring up the map type (I think it can be done in a more elegant way.) This enables us to do such nice queries as: 
```SELECT labels['service_name'], COUNT(*) FROM TABLE(default.loki(QUERY => '{source="stdout"}')) group by labels['service_name'];```